### PR TITLE
Missing flush fix

### DIFF
--- a/deltaq-tests/BsPatchTests.cs
+++ b/deltaq-tests/BsPatchTests.cs
@@ -29,13 +29,15 @@ namespace deltaq_tests
             var wrappedPatchMs = new BufferedStream(patchMs);
             BsDiff.Create(oldBuffer, newBuffer, wrappedPatchMs);
 
-            var patchBuffer = patchMs.GetBuffer();
+            var patchBuffer = patchMs.ToArray();
 
             var reconstructMs = new MemoryStream();
             var wrappedReconstructMs = new BufferedStream(reconstructMs);
             BsPatch.Apply(oldBuffer, patchBuffer, wrappedReconstructMs);
 
-            Assert.Equal(newBuffer, reconstructMs.GetBuffer());
+            var reconstructedBuffer = reconstructMs.ToArray();
+
+            Assert.Equal(newBuffer, reconstructedBuffer);
         }
     }
 }

--- a/deltaq-tests/BsPatchTests.cs
+++ b/deltaq-tests/BsPatchTests.cs
@@ -1,0 +1,41 @@
+﻿using deltaq.BsDiff;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace deltaq_tests
+{
+    public class BsPatchTests
+    {
+        private static RNGCryptoServiceProvider _cryptoRNG = new RNGCryptoServiceProvider();
+        private static byte[] GetRandomFilledBuffer(int count)
+        {
+            var buffer = new byte[count];
+            _cryptoRNG.GetBytes(buffer);
+            return buffer;
+        }
+
+        [Fact]
+        public void BsPatchFlushesOutput()
+        {
+            var oldBuffer = GetRandomFilledBuffer(0x123);
+            var newBuffer = GetRandomFilledBuffer(0x4567);
+            
+            //can't use MemoryStream directly as Flush has no effect
+            var patchMs = new MemoryStream();
+            var wrappedPatchMs = new BufferedStream(patchMs);
+            BsDiff.Create(oldBuffer, newBuffer, wrappedPatchMs);
+
+            var patchBuffer = patchMs.GetBuffer();
+
+            var reconstructMs = new MemoryStream();
+            var wrappedReconstructMs = new BufferedStream(reconstructMs);
+            BsPatch.Apply(oldBuffer, patchBuffer, wrappedReconstructMs);
+
+            Assert.Equal(newBuffer, reconstructMs.GetBuffer());
+        }
+    }
+}

--- a/deltaq-tests/deltaq-tests.csproj
+++ b/deltaq-tests/deltaq-tests.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>deltaq-tests</AssemblyName>
     <PackageId>deltaq-tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.3</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net46</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -17,9 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.2.build4010">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.0-beta.2.build4010" />
   </ItemGroup>
 
 </Project>

--- a/deltaq/BsDiff/BsPatch.cs
+++ b/deltaq/BsDiff/BsPatch.cs
@@ -132,6 +132,7 @@ namespace deltaq.BsDiff
             if (!output.CanWrite)
                 throw new ArgumentException("Output stream must be writable", nameof(output));
 
+            using (output)
             using (ctrl)
             using (diff)
             using (extra)

--- a/deltaq/deltaq.csproj
+++ b/deltaq/deltaq.csproj
@@ -14,7 +14,6 @@ Supports creating and applying patches in BSDIFF format</Description>
     <PackageProjectUrl>https://github.com/jzebedee/deltaq</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/jzebedee/deltaq/blob/master/LICENSE.md</PackageLicenseUrl>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
Fixes a bug where BsPatch fails to flush the output stream after applying all diff data, sometimes resulting in data loss if the output stream is not flushed by the caller.