### PR TITLE
Massive Span<T> optimizations

### DIFF
--- a/deltaq/BsDiff/BsPatch.cs
+++ b/deltaq/BsDiff/BsPatch.cs
@@ -92,18 +92,18 @@ namespace deltaq.BsDiff
                 if (!patchStream.CanSeek)
                     throw new ArgumentException("Patch stream must be seekable", nameof(openPatchStream));
 
-                var header = new byte[BsDiff.HeaderSize];
-                patchStream.Read(header, 0, BsDiff.HeaderSize);
+                Span<byte> header = stackalloc byte[BsDiff.HeaderSize];
+                patchStream.Read(header);
 
                 // check for appropriate magic
-                var signature = header.ReadLong();
+                var signature = Extensions.ReadLong(header);
                 if (signature != BsDiff.Signature)
                     throw new InvalidOperationException("Corrupt patch");
 
                 // read lengths from header
-                controlLength = header.ReadLongAt(8);
-                diffLength = header.ReadLongAt(16);
-                newSize = header.ReadLongAt(24);
+                controlLength = Extensions.ReadLongAt(header, 8);
+                diffLength = Extensions.ReadLongAt(header, 16);
+                newSize = Extensions.ReadLongAt(header, 24);
 
                 if (controlLength < 0 || diffLength < 0 || newSize < 0)
                     throw new InvalidOperationException("Corrupt patch");

--- a/deltaq/Bzip2/BZip2OutputStream.cs
+++ b/deltaq/Bzip2/BZip2OutputStream.cs
@@ -34,6 +34,7 @@
 // exception statement from your version.
 
 using System;
+using System.Collections;
 using System.IO;
 using bz2core.Checksums;
 
@@ -1045,7 +1046,7 @@ namespace bz2core
 
         void QSort3(int loSt, int hiSt, int dSt)
         {
-            var stack = new StackElement[QSORT_STACK_SIZE];
+            Span<StackElement> stack = stackalloc StackElement[QSORT_STACK_SIZE];
 
             var sp = 0;
 

--- a/deltaq/Extensions.cs
+++ b/deltaq/Extensions.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace deltaq
 {
@@ -45,13 +46,13 @@ namespace deltaq
         #endregion
 
         #region Long Read/Write
-        public static void WriteLongAt(this byte[] pb, int offset, long y)
+        public static void WriteLongAt(this Span<byte> pb, int offset, long y)
         {
             pb.Slice(offset, sizeof(long)).WriteLong(y);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLong(this IList<byte> b, long y)
+        public static void WriteLong(this Span<byte> b, long y)
         {
             if (y < 0)
             {
@@ -81,20 +82,20 @@ namespace deltaq
 
         public static long ReadLong(this Stream stream)
         {
-            var buf = new byte[sizeof(long)];
-            if (stream.Read(buf, 0, sizeof(long)) != sizeof(long))
+            Span<byte> buf = stackalloc byte[sizeof(long)];
+            if (stream.Read(buf) != sizeof(long))
                 throw new InvalidOperationException("Could not read long from stream");
 
-            return buf.ReadLong();
+            return ReadLong(buf);
         }
 
-        public static long ReadLongAt(this byte[] buf, int offset)
+        public static long ReadLongAt(this ReadOnlySpan<byte> buf, int offset)
         {
             return buf.Slice(offset, sizeof(long)).ReadLong();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long ReadLong(this IList<byte> b)
+        public static long ReadLong(this ReadOnlySpan<byte> b)
         {
             long y = b[7] & 0x7F;
             y <<= 8; y += b[6];

--- a/deltaq/SuffixSort/ISuffixSort.cs
+++ b/deltaq/SuffixSort/ISuffixSort.cs
@@ -1,7 +1,9 @@
-﻿namespace deltaq.SuffixSort
+﻿using System;
+
+namespace deltaq.SuffixSort
 {
     public interface ISuffixSort
     {
-        int[] Sort(byte[] buffer);
+        int[] Sort(ReadOnlySpan<byte> buffer);
     }
 }

--- a/deltaq/deltaq.csproj
+++ b/deltaq/deltaq.csproj
@@ -1,24 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>deltaq is a .NET Core class library for fast delta encoding in .NET
+    <PropertyGroup>
+        <Description>deltaq is a .NET Core class library for fast delta encoding in .NET
 
-Supports creating and applying patches in BSDIFF format</Description>
-    <AssemblyTitle>deltaq</AssemblyTitle>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <Authors>J. Zebedee</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>deltaq</AssemblyName>
-    <PackageId>deltaq</PackageId>
-    <PackageTags>diff difference patch compare delta deltaq sync bsdiff vcdiff</PackageTags>
-    <PackageProjectUrl>https://github.com/jzebedee/deltaq</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/jzebedee/deltaq/blob/master/LICENSE.md</PackageLicenseUrl>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.2.0</Version>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
+            Supports creating and applying patches in BSDIFF format
+        </Description>
+        <AssemblyTitle>deltaq</AssemblyTitle>
+        <VersionPrefix>1.1.0</VersionPrefix>
+        <Authors>J. Zebedee</Authors>
+        <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+        <AssemblyName>deltaq</AssemblyName>
+        <PackageId>deltaq</PackageId>
+        <PackageTags>diff difference patch compare delta deltaq sync bsdiff vcdiff</PackageTags>
+        <PackageProjectUrl>https://github.com/jzebedee/deltaq</PackageProjectUrl>
+        <PackageLicenseUrl>https://github.com/jzebedee/deltaq/blob/master/LICENSE.md</PackageLicenseUrl>
+        <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <Version>1.2.0</Version>
+        <SignAssembly>false</SignAssembly>
+        <LangVersion>7.3</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    </ItemGroup>
+    
 
 </Project>


### PR DESCRIPTION
Basically rewrites the whole thing to use `Span<T>`. This does mean it doesn't support netstandard2.0 anymore but if that is a big problem there are some workarounds I can do to restore it, probably.

This is *significantly* faster and cuts down on the ridiculous amount of `IList<T>` allocations (seriously...).

Before:

![image](https://user-images.githubusercontent.com/8107459/107956670-c45f5f80-6f9f-11eb-9a18-37b9e3d24f18.png)

After:

![image](https://user-images.githubusercontent.com/8107459/107956695-cde8c780-6f9f-11eb-8099-befdfef0d3cd.png)

(test case was diffing the contents of a zip file)

Most of the remaining allocations (and a good chunk of CPU time...) are in bzip2 now. It should probably be possible to opt out of bzip2? But that's for another PR.